### PR TITLE
Added `install_sfml` function to install sfml from package manager wh…

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,8 +1,43 @@
 #!/usr/bin/env bash
 compile() {
-	# Compile and clean using Makefile
+	# determine if sfml is already installed,
+	# if its not then install it
+	ldconfig -p | grep -q libsfml
+	if [ $? -ne 0 ]; then
+		install_sfml
+	fi
+
+	# Compile; Makefile is not used for now because
+	# it is not working as intended
 	echo Compiling visualizer...
-	make
+	g++ *.cpp -o sorting-visualizer -lsfml-graphics -lsfml-window -lsfml-system
+}
+
+install_sfml() {
+	# detect the package manager and install sfml
+	# accordingly
+
+	# we need to be root to install packages
+	if [ "$EUID" -ne 0 ]; then
+		echo "The SFML library needs to be installed to compile the program."
+		echo "This script can attempt to install SFML using the system package manager if run as root."
+		echo "Please run it again as root (sudo ./install.sh) or install SFML yourself."
+		exit
+	fi
+
+	if command -v pacman &>/dev/null; then
+		pacman -S sfml
+	elif command -v apt-get &>/dev/null; then
+		apt-get install libsfml-dev
+	elif command -v dnf &>/dev/null; then
+		dnf install SFML
+	else
+		# package manager was not found
+		# maybe compile sfml ourselves?
+		echo "Could not install SFML using the system package manager."
+		echo "Please install SFML yourself and run this script again."
+		exit
+	fi
 }
 
 main() {


### PR DESCRIPTION
Added `install_sfml` function to install sfml from package manager when run as root,
and call it in `compile` if sfml was not already found on the system.
Updated `compile` function to use `g++` directly rather than the Makefile