### PR TITLE
Add Bitonic Sort

### DIFF
--- a/src/SortAlgorithms.h
+++ b/src/SortAlgorithms.h
@@ -10,6 +10,7 @@ namespace algo {
 	int quickSort(std::vector<Sortable>& sortElements, int timeSleep, const std::atomic<bool>& interrupt);
 	int cocktailSort(std::vector<Sortable>& sortElements, int timeSleep, const std::atomic<bool>& interrupt);
 	int bogoSort(std::vector<Sortable>& sortElements, int timeSleep, const std::atomic<bool>& interrupt);
+	int bitonicSort(std::vector<Sortable>& sortElements, int timeSleep, const std::atomic<bool>& interrupt);
 }
 
 namespace algoUtils {

--- a/src/SortController.cpp
+++ b/src/SortController.cpp
@@ -118,6 +118,9 @@ void SortController::_startSort(int sortType) {
 		case 5:
 			numOfComparisons += algo::bogoSort(_sortElements, _timeSleep, _interrupt);
 			break;
+		case 6:
+			numOfComparisons += algo::bitonicSort(_sortElements, _timeSleep, _interrupt);
+			break;
 		default:
 			return;
 		}

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -29,6 +29,9 @@ std::string Utils::getSortType(int sortType) {
 	case 5:
 		return "Bogo sort";
 
+	case 6:
+		return "Bitonic sort";
+
 	default:
 		return kNoSort;
 	}


### PR DESCRIPTION
Added Bitonic Sort.

Since classic bitonic sort requires sizes of powers of 2, this implementation adds padding if it is not the case. 
It may not look so good in the visualisation, so I still recommend using powers of 2 for this algorithm.