### PR TITLE
Update CmakeLists.txt for building on windows and add some informatio…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,12 +1,45 @@
 cmake_minimum_required(VERSION 3.22)
 project(sorting-visualizer)
 
-set(SFML_DIR "lib/SFML-2.5.1/lib/cmake/SFML")
+set(default_build_type "Release")
+if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+  message( STATUS "Setting build type to '${default_build_type}' as none was specified.")
+  set(CMAKE_BUILD_TYPE "${default_build_type}" CACHE STRING "Choose the type of build." FORCE)
+  # Set the possible values of build type for cmake-gui
+  set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS
+    "Debug" "Release" "MinSizeRel" "RelWithDebInfo")
+endif()
 
+set(SFML_DIR "C:/Program Files (x86)/SFML/lib/cmake/SFML")
 
-find_package(SFML COMPONENTS graphics window REQUIRED)
+find_package(SFML COMPONENTS graphics window CONFIG REQUIRED)
 
 add_executable(sorting-visualizer src/main.cpp src/Sortable.cpp src/SortAlgorithms.cpp src/SortController.cpp src/Utils.cpp)
 
 target_link_libraries(sorting-visualizer sfml-graphics sfml-window)
+
+# Copy across .dlls for windows users
+get_target_property(SFML_TYPE sfml-graphics TYPE)
+if(SFML_TYPE STREQUAL "SHARED_LIBRARY")
+  message(STATUS "Copying sfml-graphics DLLs to ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>")
+  add_custom_command(
+  TARGET sorting-visualizer POST_BUILD
+  COMMAND ${CMAKE_COMMAND} -E copy
+  $<TARGET_FILE:sfml-graphics>
+  ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>)
+  
+  message(STATUS "Copying sfml-window DLLs to ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>")  
+  add_custom_command(
+  TARGET sorting-visualizer POST_BUILD
+  COMMAND ${CMAKE_COMMAND} -E copy
+  $<TARGET_FILE:sfml-window>
+  ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>)
+  
+  message(STATUS "Copying sfml-system DLLs to ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>")  
+  add_custom_command(
+  TARGET sorting-visualizer POST_BUILD
+  COMMAND ${CMAKE_COMMAND} -E copy
+  $<TARGET_FILE:sfml-system>
+  ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>)
+endif()
 

--- a/README.md
+++ b/README.md
@@ -53,3 +53,5 @@ Awesome! [Here](https://github.com/alesbe/sorting-visualizer/wiki) you can find 
 
 ### 🖥️ Windows / MacOS
 The libraries included with the project only work with gcc compiler, for now, if you want to use it on Windows or macOS, you'll need to [download sfml](https://www.sfml-dev.org/download/sfml/2.5.1/) and compile the source code located in `/src` yourself.
+
+Once you have compiled the source files you can set `SFML_DIR` in `CMakeLists.txt` to the path which contains SFMLConfig.cmake. This will depend on where you have installed SFML to, for instance `C:/Program Files (x86)/SFML/lib/cmake/SFML`. From the root directory of the repository run `mkdir build cd build` and then run `cmake ..` to generate make files. For a list of generators you can type`cmake -G`. For instance if you want to build for the latest version of Visual Studio run `cmake -G 'Visual Studio 17 2022' ..` from within `/build`.


### PR DESCRIPTION
Hi @alesbe 

I think we both had some trouble building on windows before. Took me a bit of time over the past few days but eventually got it to work with the latest version of visual studio. I'm opening this pull request as I made some small changes to CMakeLists.txt which helped me get things working on Windows. 

List of changes:

- running  `cmake -G 'Visual Studio 17 2022'` generates four kinds of releases by default ("Debug", "Release", "MinSizeRel", "RelWithDebInfo") so I added some code to account for this. 
- changed the mode of `find_package` to `CONFIG` mode. This will search for SFMLConfig.cmake in the SFML_DIR. 
- added code to copy across the .dll files alongside the executable. Without this cmake runs fine, visual studio project builds fine, but when running there is an error about the dlls not being found. 

I haven't yet tested on linux, was hoping you might be able to if you have some spare time. 

Let me know of any issues, comments, suggestions and I can fix them up! :) 