### PR TITLE
Add Odd-Even sort

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ Awesome! [Here](https://github.com/alesbe/sorting-visualizer/wiki) you can find 
   - Bogo sort is an inefficient sorting algorithm where it randomly generates different versions of the original dataset and checks if it's sorted or not. More on bogo sort can be found [here](https://www.geeksforgeeks.org/bogosort-permutation-sort/).
 - **Bitonic sort**
   - Bitonic sort is a comparison based sorting algorithm that can be run with parallel implementation. Within different subarrays, the algorithm checks if the first element is smaller than the second and vice versa. It continuously does that on larger subarrays until the whole dataset is sorted. More on bitonic sort can be found [here](https://www.geeksforgeeks.org/bitonic-sort/).
+- **Odd-Even sort**
+ - Odd-Even sort is comparassion vased sorting algorithm developed for use on pararell processors, its based on bubble sort but is divided into two phases Odd and Even Phase. On Odd phase algorithm performs bubble sort on odd indexed elements, during even phase on even indexed elements. More on Odd-Even sort can be found [here](https://www.geeksforgeeks.org/odd-even-sort-brick-sort/).
+
 
 ## 🕹️ Usage
 - **Space**: Start sort <br>

--- a/src/SortAlgorithms.cpp
+++ b/src/SortAlgorithms.cpp
@@ -336,6 +336,36 @@ int algo::bitonicSort(std::vector<Sortable>& sortElements, int timeSleep, const 
 
 	return numOfComparisons;
 }
+/**
+ * @brief Odd-Even/Brick sort
+ * @author @Niko-the-Useless
+ * @param sortElements Main array containing the elements to be sorted
+ * @param timeSleep Time to wait between iterations in miliseconds
+ * @param interrupt Bool to stop the sort process
+ * @return Number of comparisons made
+ */
+
+int algo::oddEvenSort(std::vector<Sortable>& sortElements, int timeSleep, const std::atomic<bool>& interrupt){
+	int numOfComparisons = 0;
+	
+	for(int n=1;n<=sortElements.size()-2;n=n+2){ //bubble sort for odd elements
+		if (interrupt){return numOfComparisons;}
+		if(sortElements[n].value>sortElements[n+1].value){
+			algoUtils::swap(sortElements, timeSleep, sortElements[n], sortElements[n+1]);
+		}
+		numOfComparisons++;
+	}
+	
+	for(int n=0;n<=sortElements.size()-2;n=n+2){ //bubble sort for even elements
+		if (interrupt){return numOfComparisons;}
+		if(sortElements[n].value>sortElements[n+1].value){
+			algoUtils::swap(sortElements, timeSleep, sortElements[n], sortElements[n+1]);
+		}
+		numOfComparisons++;
+	}
+
+	return numOfComparisons; 
+}
 
 //
 // ────────────────────────────────────────────────────────── II ──────────

--- a/src/SortAlgorithms.h
+++ b/src/SortAlgorithms.h
@@ -11,6 +11,7 @@ namespace algo {
 	int cocktailSort(std::vector<Sortable>& sortElements, int timeSleep, const std::atomic<bool>& interrupt);
 	int bogoSort(std::vector<Sortable>& sortElements, int timeSleep, const std::atomic<bool>& interrupt);
 	int bitonicSort(std::vector<Sortable>& sortElements, int timeSleep, const std::atomic<bool>& interrupt);
+	int oddEvenSort(std::vector<Sortable>& sortElements, int timeSleep, const std::atomic<bool>& interrupt);
 }
 
 namespace algoUtils {

--- a/src/SortController.cpp
+++ b/src/SortController.cpp
@@ -121,6 +121,9 @@ void SortController::_startSort(int sortType) {
 		case 6:
 			numOfComparisons += algo::bitonicSort(_sortElements, _timeSleep, _interrupt);
 			break;
+		case 7:
+			numOfComparisons += algo::oddEvenSort(_sortElements, _timeSleep, _interrupt);
+			break;
 		default:
 			return;
 		}

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -32,6 +32,9 @@ std::string Utils::getSortType(int sortType) {
 	case 6:
 		return "Bitonic sort";
 
+	case 7:
+		return "Odd-Even sort";
+
 	default:
 		return kNoSort;
 	}


### PR DESCRIPTION
Add [Odd-Even sort](https://www.geeksforgeeks.org/odd-even-sort-brick-sort/)
algorithm based on bubble sort, developed for use on parallel processors in 1972